### PR TITLE
Fix extraction of embedded resources in collection responses

### DIFF
--- a/src/theseus/extractor.js
+++ b/src/theseus/extractor.js
@@ -1,9 +1,20 @@
 import {Resource} from './resource';
-import {isArray, isObject, isDefined} from './util';
-
+import {isArray, isObject, isDefined, isUndefined} from './util';
 
 function contains(arr, item) {
   return arr.indexOf(item) !== -1;
+}
+
+
+var baseEntityProperties = ['uri', 'data', 'links'];
+var collectionEntityProperties = ['length', 'offset', 'total'];
+
+function allowedEntityProperties(entityIsCollection) {
+  if (entityIsCollection) {
+    return baseEntityProperties.concat(collectionEntityProperties);
+  } else {
+    return baseEntityProperties;
+  }
 }
 
 function isEntity(obj, isEmbedded) {
@@ -21,7 +32,10 @@ function isEntity(obj, isEmbedded) {
   }
 
   var keys = Object.keys(obj);
-  var entityProperties = ['uri', 'data', 'links'];
+
+  // If data undefined, it may or may not be a collection
+  var dataIsArray = isUndefined(obj.data) || isArray(obj.data);
+  var entityProperties = allowedEntityProperties(dataIsArray);
   var hasOnlyEntityProps = keys.every(key => contains(entityProperties, key));
 
   return hasRequiredProps && hasOnlyEntityProps;

--- a/src/theseus/util.js
+++ b/src/theseus/util.js
@@ -10,6 +10,10 @@ export function isDefined(value) {
   return typeof value !== 'undefined';
 }
 
+export function isUndefined(value) {
+  return ! isDefined(value);
+}
+
 
 export function memoize(func) {
   var value;


### PR DESCRIPTION
There was a bug in the response parsing that prevented recursion within collection entity responses if the collection properties (total, length, offset) are present.

Fixes https://github.com/guardian/media-service/issues/339