### PR TITLE
Resource HTTP methods now return Promise[Resource] (breaking API change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Theseus [![Build Status](https://travis-ci.org/argo-rest/theseus.svg?branch=master)](https://travis-ci.org/argo-rest/theseus)
 
-A JavaScript client library for argo Hypermedia APIs.
+A JavaScript client library for [argo](https://github.com/argo-rest/spec) Hypermedia APIs.
 
 *Under development.*
 
@@ -34,5 +34,5 @@ Theseus is available as an ES6 module.
 Using [jspm](https://jspm.io/), you can install it by running:
 
 ```
-jspm install github:argo-rest/theseus
+jspm install theseus
 ```

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ import {Promise} from 'any-promise-es6';
 var client = new Client({http: new Http, promise: Promise});
 
 var resource = client.resource('http://api.example.com'); // an API supporting argo
-resource.data.then(data => console.log(data), err => console.error(err.stack));
-resource.follow('search', {query: '42'}).data.then(data => console.log(data));
-resource.follow('items').follow('create').post({foo: 'bar'}).then(resp => console.log(resp));
+resource.get().then(resource => console.log(resource), err => console.error(err.stack));
+resource.follow('search', {query: '42'}).getData().then(data => console.log(data));
+resource.follow('items').follow('create').post({foo: 'bar'}).then(res => console.log(res));
 ```
 
 See the [theseus-examples](https://github.com/argo-rest/theseus-examples) repository for live code.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "theseus",
-  "version": "0.2.0",
+  "version": "0.3.0-beta.0",
   "description": "JavaScript client library for argo Hypermedia APIs",
   "keywords": [
     "hypermedia",

--- a/src/theseus/util.js
+++ b/src/theseus/util.js
@@ -6,6 +6,10 @@ export function isObject(obj) {
   return obj instanceof Object;
 }
 
+export function isString(value) {
+  return typeof value === 'string';
+}
+
 export function isDefined(value) {
   return typeof value !== 'undefined';
 }
@@ -43,4 +47,3 @@ export function defPropertyGetter(obj, propName, getter) {
 export function defPropertyLazyValue(obj, propName, computeVal) {
   defPropertyGetter(obj, propName, memoize(computeVal));
 }
-

--- a/test/specs/resource.spec.js
+++ b/test/specs/resource.spec.js
@@ -41,7 +41,9 @@ describe('Resource', () => {
                 response = {
                     uri: exampleUri,
                     status: 200,
-                    headers: {},
+                    headers: {
+                        'Content-Type': 'application/vnd.argo+json'
+                    },
                     body: {data: {testKey: 'testVal'}}
                 };
                 http.get = sinon.stub().
@@ -53,15 +55,15 @@ describe('Resource', () => {
                 resource.get.should.be.a('function');
             });
 
-            it('should return a Resource', () => {
-                var resp = resource.get();
-                resp.should.be.instanceof(Resource);
+            it('should return a Promise', () => {
+                var res = resource.get();
+                res.should.be.instanceof(Promise);
             });
 
             it('should GET the uri from the http adapter', () => {
-                var resp = resource.get();
+                var res = resource.get();
 
-                return resp.response.then(() => {
+                return res.then(() => {
                     // FIXME: once?
                     http.get.should.have.been.calledWith(exampleUri, {});
                 });
@@ -69,9 +71,9 @@ describe('Resource', () => {
 
             it('should pass any param to the http adapter', () => {
                 var params = {param1: 'val1', param2: 'val2'};
-                var resp = resource.get(params);
+                var res = resource.get(params);
 
-                return resp.response.then(() => {
+                return res.then(() => {
                    http.get.should.have.been.calledWith(exampleUri, params);
                 });
             });
@@ -80,22 +82,26 @@ describe('Resource', () => {
 
             it('should pass any implementation options to the http adapter', () => {
                 var implemOptions = {opt1: 'val1'};
-                var resp = resource.get({}, implemOptions);
+                var res = resource.get({}, implemOptions);
 
-                return resp.response.then(() => {
+                return res.then(() => {
                    http.get.should.have.been.calledWith(exampleUri, {}, implemOptions);
                 });
             });
 
             it('should return a Resource with the same uri', () => {
-                var resp = resource.get();
-                return resp.uri.should.eventually.equal(exampleUri);
+                var res = resource.get();
+                return res.then(gotResource => {
+                    gotResource.uri.should.equal(exampleUri);
+                });
             });
 
             it('should return a Resource with the data', () => {
                 var resp = resource.get();
                 // TODO: check only one GET
-                return resp.getData().should.eventually.deep.equal({testKey: 'testVal'});
+                return resp.then(gotResource => {
+                    gotResource.getData().should.eventually.deep.equal({testKey: 'testVal'});
+                });
             });
 
             // TODO: exposed data if argo


### PR DESCRIPTION
`Resource#{get,post,put,patch,delete}` methods have been refactored to return a `Promise[Resource]`, rather than a mix of that and lazy `Resource`. This is in line with observations while using the API that it'd make theseus simpler to use.

The `uri`, `resource` and `data` properties are now also exposed synchronously on `Resource` if present (else they are left out), rather than asynchronously. The corresponding async (Promise) versions are now `$uri`, `$response` and `getData()`; `$`-prefixed properties are meant to be private and **not** accessed externally. They may be substituted for memoized getters in future versions (like `getData()`).

As a breaking API change, it will be reflected in a version bump to 0.3.0.

This fixes https://github.com/argo-rest/theseus/issues/10.