### PR TITLE
getUri helper on resource

### DIFF
--- a/src/theseus/resource.js
+++ b/src/theseus/resource.js
@@ -212,6 +212,14 @@ export class Resource {
         return link;
       });
   }
+
+  /**
+   * @return {Promise[String]}
+   */
+  getUri() {
+    return this.$uri;
+  }
+
 }
 
 


### PR DESCRIPTION
I hope I am not being massively stupid - but this seems to give what we want?
I thought you could have something like:
``` JavaScript
return this.$uri.then(uri => {
  if (! uri) {
    throw new Error('No link, go home');
  }
  return uri;
})
```

But it felt that all `Resource`s require a uri, so this could never be the case?